### PR TITLE
Allow compilation on non-windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 Easy, tiny, and portable pomodoro timer
 
 Inspired by https://github.com/Splode/pomotroid
+
+# Use on Debian (Linux)
+
+To compile on debian you first need to install the alsa dependency using `sudo apt install librust-alsa-sys-dev`

--- a/hotkeys/src/lib.rs
+++ b/hotkeys/src/lib.rs
@@ -3,6 +3,11 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use self::windows::WinHotkeys as HotkeyManager;
 
+#[cfg(not(target_os = "windows"))]
+mod non_windows;
+#[cfg(not(target_os = "windows"))]
+pub use self::non_windows::HotkeyManager;
+
 #[derive(Debug, Clone, Copy)]
 pub enum Modifiers {
     Alt,

--- a/hotkeys/src/non_windows/mod.rs
+++ b/hotkeys/src/non_windows/mod.rs
@@ -1,0 +1,35 @@
+//! This mod only allows the code to compile but does not provide the expected functionality
+
+use crate::Hotkeys;
+
+#[derive(Default)]
+pub struct HotkeyManager;
+impl Hotkeys for HotkeyManager {
+    type Key = u32;
+
+    type Id = i32;
+
+    fn register<H>(
+        &self,
+        _key: Self::Key,
+        _mods: Option<crate::Modifiers>,
+        _cb: H,
+    ) -> Option<Self::Id>
+    where
+        H: Fn() + Send + 'static,
+    {
+        // TODO: Replace empty placeholder
+        None
+    }
+
+    fn unregister(&self, _id: Self::Id) {
+        // TODO: Replace empty placeholder
+    }
+}
+
+impl HotkeyManager {
+    pub fn new() -> Self {
+        // TODO: Replace empty placeholder
+        Self {}
+    }
+}


### PR DESCRIPTION
Hi,

I've updated the readme to include the command required to install the alsa dependency to be able to compile on debian. And I've added a stub Hotkey manager when not running on Windows so that the code still compiles (without the functionality).